### PR TITLE
Buffer equality fix

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/connectors/UnmodifiableBuffer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/connectors/UnmodifiableBuffer.java
@@ -100,7 +100,7 @@ public class UnmodifiableBuffer<T> implements IBuffer<T> {
         }
         if (obj instanceof UnmodifiableBuffer) {
             UnmodifiableBuffer<?> other = (UnmodifiableBuffer<?>) obj;
-            return Objects.equals(buf, other.buf) && Objects.equals(records, records);
+            return Objects.equals(buf, other.buf) && Objects.equals(records, other.records);
         }
         return false;
     }

--- a/src/test/java/com/amazonaws/services/kinesis/connectors/KinesisConnectorRecordProcessorTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/connectors/KinesisConnectorRecordProcessorTest.java
@@ -44,7 +44,7 @@ import com.amazonaws.services.kinesis.connectors.interfaces.ITransformer;
 import com.amazonaws.services.kinesis.connectors.interfaces.ITransformerBase;
 import com.amazonaws.services.kinesis.model.Record;
 
-public class KinesisConnectorRecordProcessorTests {
+public class KinesisConnectorRecordProcessorTest {
     // control object used to create mock dependencies
     IMocksControl control;
 

--- a/src/test/java/com/amazonaws/services/kinesis/connectors/UnmodifiableBufferTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/connectors/UnmodifiableBufferTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.*;
 import com.amazonaws.services.kinesis.connectors.UnmodifiableBuffer;
 import com.amazonaws.services.kinesis.connectors.interfaces.IBuffer;
 
-public class UnmodifiableBufferTests {
+public class UnmodifiableBufferTest {
     IMocksControl control;
     IBuffer<Integer> buffer;
 

--- a/src/test/java/com/amazonaws/services/kinesis/connectors/UnmodifiableBufferTests.java
+++ b/src/test/java/com/amazonaws/services/kinesis/connectors/UnmodifiableBufferTests.java
@@ -24,6 +24,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
 
 import com.amazonaws.services.kinesis.connectors.UnmodifiableBuffer;
@@ -81,5 +82,103 @@ public class UnmodifiableBufferTests {
 
         exception.expect(UnsupportedOperationException.class);
         testRecords.clear();
+    }
+
+    @Test
+    public void testBuffersCompareRecordsForEquality() {
+        ArrayList<Integer> buffer1Records = new ArrayList<>();
+        buffer1Records.add(1);
+        buffer1Records.add(2);
+
+        ArrayList<Integer> buffer2Records = new ArrayList<>();
+
+        UnmodifiableBuffer<Integer> buffer1 = new UnmodifiableBuffer<Integer>(null, buffer1Records);
+        UnmodifiableBuffer<Integer> buffer2 = new UnmodifiableBuffer<Integer>(null, buffer2Records);
+
+        boolean equality = buffer1.equals(buffer2);
+
+        assertThat(equality, is(false));
+
+        buffer2Records.addAll(buffer1Records);
+
+        equality = buffer1.equals(buffer2);
+
+        assertThat(equality, is(true));
+    }
+
+    @Test
+    public void testBuffersCompareInnerBuffersForEquality() {
+        testBuffersUsingInnerBufferEquality(false);
+        testBuffersUsingInnerBufferEquality(true);
+    }
+
+    private void testBuffersUsingInnerBufferEquality(boolean innerBuffersAreEqual) {
+        IBuffer<Object> innerBuffer1 = new EqualityTestBuffer<>(innerBuffersAreEqual);
+        IBuffer<Object> innerBuffer2 = new EqualityTestBuffer<>(innerBuffersAreEqual);
+
+        UnmodifiableBuffer<Object> buffer1 = new UnmodifiableBuffer<Object>(innerBuffer1, null);
+        UnmodifiableBuffer<Object> buffer2 = new UnmodifiableBuffer<Object>(innerBuffer2, null);
+
+        boolean equality = buffer1.equals(buffer2);
+
+        assertThat(equality, is(innerBuffersAreEqual));
+    }
+
+    private class EqualityTestBuffer<T> implements IBuffer<T> {
+        private boolean equalsReturns;
+
+        public EqualityTestBuffer(boolean equalsReturns) {
+            this.equalsReturns = equalsReturns;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return this.equalsReturns;
+        }
+
+        @Override
+        public long getBytesToBuffer() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long getNumRecordsToBuffer() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long getMillisecondsToBuffer() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean shouldFlush() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void consumeRecord(T record, int recordBytes, String sequenceNumber) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void clear() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getFirstSequenceNumber() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getLastSequenceNumber() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<T> getRecords() {
+            throw new UnsupportedOperationException();
+        }
     }
 }

--- a/src/test/java/com/amazonaws/services/kinesis/connectors/dynamodb/DynamoDBEmitterTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/connectors/dynamodb/DynamoDBEmitterTest.java
@@ -34,7 +34,7 @@ import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.kinesis.connectors.KinesisConnectorConfiguration;
 import com.amazonaws.services.kinesis.connectors.dynamodb.DynamoDBEmitter;
 
-public class DynamoDBEmitterTests {
+public class DynamoDBEmitterTest {
     IMocksControl control;
     KinesisConnectorConfiguration config;
     AWSCredentialsProvider credsProvider;

--- a/src/test/java/com/amazonaws/services/kinesis/connectors/impl/BasicMemoryBufferTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/connectors/impl/BasicMemoryBufferTest.java
@@ -31,7 +31,7 @@ import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.services.kinesis.connectors.KinesisConnectorConfiguration;
 import com.amazonaws.services.kinesis.connectors.impl.BasicMemoryBuffer;
 
-public class BasicMemoryBufferTests {
+public class BasicMemoryBufferTest {
     KinesisConnectorConfiguration config;
 
     IMocksControl control;


### PR DESCRIPTION
Duplicating bugfix from https://github.com/awslabs/amazon-kinesis-connectors/pull/80

'UnmodifiableBuffer previously compared its own records object
against itself rather than against the records object of the
other buffer. This meant that equals would return true even
if two buffers contained different records.

Added unit tests to verify that UnmodifiableBuffer compares both
its internal IBuffer and its list of records.

Additionally, several test files did not match maven's conventions (should be *Test but was *Tests) and so were not run when executing mvn test, so I renamed them.'