### PR TITLE
reuse object mapper to reduce memory impact

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/connectors/BasicJsonTransformer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/connectors/BasicJsonTransformer.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public abstract class BasicJsonTransformer<T, U> implements ITransformer<T, U> {
     private static final Log LOG = LogFactory.getLog(BasicJsonTransformer.class);
+    protected static final ObjectMapper objectMapper = new ObjectMapper();
     protected Class<T> inputClass;
 
     public BasicJsonTransformer(Class<T> inputClass) {
@@ -42,7 +43,7 @@ public abstract class BasicJsonTransformer<T, U> implements ITransformer<T, U> {
     @Override
     public T toClass(Record record) throws IOException {
         try {
-            return new ObjectMapper().readValue(record.getData().array(), this.inputClass);
+            return objectMapper.readValue(record.getData().array(), this.inputClass);
         } catch (IOException e) {
             String message = "Error parsing record from JSON: " + new String(record.getData().array());
             LOG.error(message, e);

--- a/src/main/java/com/amazonaws/services/kinesis/connectors/impl/JsonToByteArrayTransformer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/connectors/impl/JsonToByteArrayTransformer.java
@@ -14,14 +14,11 @@
  */
 package com.amazonaws.services.kinesis.connectors.impl;
 
-import java.io.IOException;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import com.amazonaws.services.kinesis.connectors.BasicJsonTransformer;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * The JsonToByteArrayTransformer defines a BasicJsonTransformer with byte array for its output
@@ -37,7 +34,7 @@ public class JsonToByteArrayTransformer<T> extends BasicJsonTransformer<T, byte[
     @Override
     public byte[] fromClass(T record) throws IOException {
         try {
-            return new ObjectMapper().writeValueAsString(record).getBytes();
+            return objectMapper.writeValueAsString(record).getBytes();
         } catch (JsonProcessingException e) {
             String message = "Error parsing record to JSON";
             LOG.error(message, e);

--- a/src/main/java/com/amazonaws/services/kinesis/connectors/impl/JsonToByteArrayTransformer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/connectors/impl/JsonToByteArrayTransformer.java
@@ -34,7 +34,7 @@ public class JsonToByteArrayTransformer<T> extends BasicJsonTransformer<T, byte[
     @Override
     public byte[] fromClass(T record) throws IOException {
         try {
-            return objectMapper.writeValueAsString(record).getBytes();
+            return objectMapper.writeValueAsBytes(record);
         } catch (JsonProcessingException e) {
             String message = "Error parsing record to JSON";
             LOG.error(message, e);


### PR DESCRIPTION
Duplicate of https://github.com/awslabs/amazon-kinesis-connectors/pull/74

'ObjectMapper is safe to share.'