### PR TITLE
Pass shard ID into IEmitter.emit()

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ To run a sample, complete these steps:
 4. Within the sample folder, execute **ant run**.
 
 ## Release Notes
+### Release 1.2.2 (Jun 1, 2016)
++ Pass shard ID into the emit method of the IEmitter interface
+
 ### Release 1.2.0 (June 23, 2015)
 + Upgraded KCL to 1.4.0
 + Added pipelined record processor that decouples Amazon Kinesis GetRecords() and IRecordProcessor's ProcessRecords() API calls for efficiency.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>amazon-kinesis-connectors</artifactId>
     <packaging>jar</packaging>
     <name>Amazon Kinesis Connector Library</name>
-    <version>1.2.0</version>
+    <version>1.2.2</version>
     <description>The Amazon Kinesis Connector Library helps Java developers integrate Amazon Kinesis with other AWS and non-AWS services.</description>
     <url>https://aws.amazon.com/kinesis</url>
 

--- a/src/main/java/com/amazonaws/services/kinesis/connectors/KinesisConnectorRecordProcessor.java
+++ b/src/main/java/com/amazonaws/services/kinesis/connectors/KinesisConnectorRecordProcessor.java
@@ -159,7 +159,7 @@ public class KinesisConnectorRecordProcessor<T, U> implements IRecordProcessor {
         List<U> unprocessed = new ArrayList<U>(emitItems);
         try {
             for (int numTries = 0; numTries < retryLimit; numTries++) {
-                unprocessed = emitter.emit(new UnmodifiableBuffer<U>(buffer, unprocessed));
+                unprocessed = emitter.emit(new UnmodifiableBuffer<U>(buffer, unprocessed), shardId);
                 if (unprocessed.isEmpty()) {
                     break;
                 }

--- a/src/main/java/com/amazonaws/services/kinesis/connectors/dynamodb/DynamoDBEmitter.java
+++ b/src/main/java/com/amazonaws/services/kinesis/connectors/dynamodb/DynamoDBEmitter.java
@@ -60,8 +60,8 @@ public class DynamoDBEmitter implements IEmitter<Map<String, AttributeValue>> {
     }
 
     @Override
-    public List<Map<String, AttributeValue>> emit(final UnmodifiableBuffer<Map<String, AttributeValue>> buffer)
-        throws IOException {
+    public List<Map<String, AttributeValue>> emit(final UnmodifiableBuffer<Map<String, AttributeValue>> buffer,
+        String shardId) throws IOException {
         // Map of WriteRequests to records for reference
         Map<WriteRequest, Map<String, AttributeValue>> requestMap =
                 new HashMap<WriteRequest, Map<String, AttributeValue>>();

--- a/src/main/java/com/amazonaws/services/kinesis/connectors/elasticsearch/ElasticsearchEmitter.java
+++ b/src/main/java/com/amazonaws/services/kinesis/connectors/elasticsearch/ElasticsearchEmitter.java
@@ -148,7 +148,8 @@ public class ElasticsearchEmitter implements IEmitter<ElasticsearchObject> {
      * loss occurs and simplifies restarting the application once issues have been fixed.
      */
     @Override
-    public List<ElasticsearchObject> emit(UnmodifiableBuffer<ElasticsearchObject> buffer) throws IOException {
+    public List<ElasticsearchObject> emit(UnmodifiableBuffer<ElasticsearchObject> buffer,
+        String shardId) throws IOException {
         List<ElasticsearchObject> records = buffer.getRecords();
         if (records.isEmpty()) {
             return Collections.emptyList();

--- a/src/main/java/com/amazonaws/services/kinesis/connectors/interfaces/IEmitter.java
+++ b/src/main/java/com/amazonaws/services/kinesis/connectors/interfaces/IEmitter.java
@@ -39,12 +39,14 @@ public interface IEmitter<T> {
      * 
      * @param buffer
      *        The full buffer of records
+     * @param shardId
+     *        The ID of the shard where the records originated
      * @throws IOException
      *         A failure was reached that is not recoverable, no retry will occur and the fail
      *         method will be called
      * @return A list of records that failed to emit to be retried
      */
-    List<T> emit(UnmodifiableBuffer<T> buffer) throws IOException;
+    List<T> emit(UnmodifiableBuffer<T> buffer, String shardId) throws IOException;
 
     /**
      * This method defines how to handle a set of records that cannot successfully be emitted.

--- a/src/main/java/com/amazonaws/services/kinesis/connectors/redshift/RedshiftBasicEmitter.java
+++ b/src/main/java/com/amazonaws/services/kinesis/connectors/redshift/RedshiftBasicEmitter.java
@@ -71,8 +71,8 @@ public class RedshiftBasicEmitter extends S3Emitter {
     }
 
     @Override
-    public List<byte[]> emit(final UnmodifiableBuffer<byte[]> buffer) throws IOException {
-        List<byte[]> failed = super.emit(buffer);
+    public List<byte[]> emit(final UnmodifiableBuffer<byte[]> buffer, String shardId) throws IOException {
+        List<byte[]> failed = super.emit(buffer, shardId);
         if (!failed.isEmpty()) {
             return buffer.getRecords();
         }

--- a/src/main/java/com/amazonaws/services/kinesis/connectors/redshift/RedshiftManifestEmitter.java
+++ b/src/main/java/com/amazonaws/services/kinesis/connectors/redshift/RedshiftManifestEmitter.java
@@ -105,7 +105,7 @@ public class RedshiftManifestEmitter implements IEmitter<String> {
     }
 
     @Override
-    public List<String> emit(final UnmodifiableBuffer<String> buffer) throws IOException {
+    public List<String> emit(final UnmodifiableBuffer<String> buffer, String shardId) throws IOException {
         List<String> records = buffer.getRecords();
         Connection conn = null;
 

--- a/src/main/java/com/amazonaws/services/kinesis/connectors/s3/S3Emitter.java
+++ b/src/main/java/com/amazonaws/services/kinesis/connectors/s3/S3Emitter.java
@@ -62,7 +62,7 @@ public class S3Emitter implements IEmitter<byte[]> {
     }
 
     @Override
-    public List<byte[]> emit(final UnmodifiableBuffer<byte[]> buffer) throws IOException {
+    public List<byte[]> emit(final UnmodifiableBuffer<byte[]> buffer, String shardId) throws IOException {
         List<byte[]> records = buffer.getRecords();
         // Write all of the records to a compressed output stream
         ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/src/main/java/com/amazonaws/services/kinesis/connectors/s3/S3ManifestEmitter.java
+++ b/src/main/java/com/amazonaws/services/kinesis/connectors/s3/S3ManifestEmitter.java
@@ -58,10 +58,10 @@ public class S3ManifestEmitter extends S3Emitter {
     }
 
     @Override
-    public List<byte[]> emit(final UnmodifiableBuffer<byte[]> buffer) throws IOException {
+    public List<byte[]> emit(final UnmodifiableBuffer<byte[]> buffer, String shardId) throws IOException {
         // Store the contents of buffer.getRecords because superclass will
         // clear the buffer on success
-        List<byte[]> failed = super.emit(buffer);
+        List<byte[]> failed = super.emit(buffer, shardId);
         // calls S3Emitter to write objects to Amazon S3
         if (!failed.isEmpty()) {
             return buffer.getRecords();


### PR DESCRIPTION
For the S3Emitter, it is necessary to include the shard ID in the S3
filename in order to properly handle duplicate records on the consumer
side as recommended here:

http://docs.aws.amazon.com/streams/latest/dev/kinesis-record-processor-duplicates.html

(Duplicated from https://github.com/awslabs/amazon-kinesis-connectors/pull/72 )